### PR TITLE
Fix Gradle 5.2 compatibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/felipefzdz/gradle/heroku/HerokuBasePlugin.groovy
+++ b/src/main/groovy/com/felipefzdz/gradle/heroku/HerokuBasePlugin.groovy
@@ -20,13 +20,6 @@ class HerokuBasePlugin implements Plugin<Project> {
 
     public static final String HEROKU_EXTENSION_NAME = 'heroku'
 
-    private final Instantiator instantiator
-
-    @Inject
-    HerokuBasePlugin(Instantiator instantiator) {
-        this.instantiator = instantiator
-    }
-
     @Override
     void apply(Project project) {
         Graph.init(project.logger)
@@ -46,6 +39,11 @@ class HerokuBasePlugin implements Plugin<Project> {
 
     @Inject
     protected CollectionCallbackActionDecorator getCollectionCallbackActionDecorator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected Instantiator getInstantiator() {
         throw new UnsupportedOperationException();
     }
 
@@ -91,6 +89,7 @@ class HerokuBasePlugin implements Plugin<Project> {
 
     HerokuAppContainer createHerokuAppContainer(Project project, String bundleName) {
         def container
+        def instantiator = getInstantiator()
         if(GradleVersion.current().compareTo(GradleVersion.version('5.1')) >= 0) {
             CollectionCallbackActionDecorator decorator = project.services.get(CollectionCallbackActionDecorator)
             container = instantiator.newInstance(HerokuAppContainer, bundleName, instantiator, decorator)


### PR DESCRIPTION
This fixes the compatibility of the heroku plugin with gradle >= gradle 5.2. There were change made that changed the handling of constructor injection in the Gradle build tool that makes this change necessary